### PR TITLE
CIN-921 Adding support for the contentful preview api to hugo export

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ contentful-hugo [Flags]
 
 Flags:
  -space-id=value      "Id of the contentful space from which to extract content. If not present will default to an environment variable named `$CONTENTFUL_API_SPACE`"
- -api-token=value     "API Key used to authenticate with contentful for content delivery. If not present will default to an environment variable named `$CONTENTFUL_API_KEY`"
+ -api-token=value     "API Key used to authenticate with contentful for content delivery. If not present will default to an environment variable named `$CONTENTFUL_API_KEY`. The preview API key should be provided if -p is used."
  -config-file=value   "Path to the config TOML file to load. Defauls to `./extract-config.tml`"
+ -p                   "If present, the contentful preview API will be used so that draft content will be included as part of the export."
  ```
 
 The tool requires two parameters to work, a contentful space id and API key. These can be provided as command line flags or as environment variables

--- a/main.go
+++ b/main.go
@@ -15,19 +15,20 @@ func main() {
 	space := flag.String("space-id", os.Getenv("CONTENTFUL_API_SPACE"), "The contentful space id to export data from")
 	key := flag.String("api-key", os.Getenv("CONTENTFUL_API_KEY"), "The contentful delivery API access token")
 	config := flag.String("config-file", "extract-config.toml", "Path to the TOML config file to load for export config")
-
+	preview := flag.Bool("p", false, "Use contentful's preview API so that draft content is downloaded")
 	flag.Parse()
+
 	fmt.Println("Begin contentful export : ", *space)
 	extractor := extract.Extractor{
-		read.ReadConfig{
-			"https://cdn.contentful.com",
-			*space,
-			*key,
-			"en-US",
+		ReadConfig: read.ReadConfig{
+			UsePreview:  *preview,
+			SpaceID:     *space,
+			AccessToken: *key,
+			Locale:      "en-US",
 		},
-		read.HttpGetter{},
-		translate.LoadConfig(*config),
-		write.FileStore{},
+		Getter:      read.HttpGetter{},
+		TransConfig: translate.LoadConfig(*config),
+		Store:       write.FileStore{},
 	}
 
 	err := extractor.ProcessAll()

--- a/read/config.go
+++ b/read/config.go
@@ -1,7 +1,7 @@
 package read
 
 type ReadConfig struct {
-	UrlBase     string
+	UsePreview  bool
 	SpaceID     string
 	AccessToken string
 	Locale      string

--- a/read/contentful.go
+++ b/read/contentful.go
@@ -13,24 +13,28 @@ type Contentful struct {
 	ReadConfig ReadConfig
 }
 
+// Types will use Contentful's content_types endpoint to retrieve all content types from contentful
 func (c *Contentful) Types() (rc io.ReadCloser, err error) {
-	urlBase := URL
-	if c.ReadConfig.UsePreview {
-		urlBase = previewURL
-	}
-	return c.Getter.Get(urlBase + "/spaces/" +
+
+	return c.get("/spaces/" +
 		c.ReadConfig.SpaceID + "/content_types?access_token=" +
 		c.ReadConfig.AccessToken + "&limit=200&locale=" +
 		c.ReadConfig.Locale)
 }
 
+// Items will use Contentful's entires endpoint to retrieve all 'items' from contetnful
 func (c *Contentful) Items(skip int) (rc io.ReadCloser, err error) {
+
+	return c.get("/spaces/" +
+		c.ReadConfig.SpaceID + "/entries?access_token=" +
+		c.ReadConfig.AccessToken + "&limit=200&locale=" +
+		c.ReadConfig.Locale + "&skip=" + strconv.Itoa(skip))
+}
+
+func (c *Contentful) get(endpoint string) (rc io.ReadCloser, err error) {
 	urlBase := URL
 	if c.ReadConfig.UsePreview {
 		urlBase = previewURL
 	}
-	return c.Getter.Get(urlBase + "/spaces/" +
-		c.ReadConfig.SpaceID + "/entries?access_token=" +
-		c.ReadConfig.AccessToken + "&limit=200&locale=" +
-		c.ReadConfig.Locale + "&skip=" + strconv.Itoa(skip))
+	return c.Getter.Get(urlBase + endpoint)
 }

--- a/read/contentful.go
+++ b/read/contentful.go
@@ -5,21 +5,31 @@ import (
 	"strconv"
 )
 
+const previewURL string = "https://preview.contentful.com"
+const URL string = "https://cdn.contentful.com"
+
 type Contentful struct {
 	Getter     Getter
 	ReadConfig ReadConfig
 }
 
 func (c *Contentful) Types() (rc io.ReadCloser, err error) {
-	return c.Getter.Get(c.ReadConfig.UrlBase + "/spaces/" +
+	urlBase := URL
+	if c.ReadConfig.UsePreview {
+		urlBase = previewURL
+	}
+	return c.Getter.Get(urlBase + "/spaces/" +
 		c.ReadConfig.SpaceID + "/content_types?access_token=" +
 		c.ReadConfig.AccessToken + "&limit=200&locale=" +
 		c.ReadConfig.Locale)
 }
 
 func (c *Contentful) Items(skip int) (rc io.ReadCloser, err error) {
-
-	return c.Getter.Get(c.ReadConfig.UrlBase + "/spaces/" +
+	urlBase := URL
+	if c.ReadConfig.UsePreview {
+		urlBase = previewURL
+	}
+	return c.Getter.Get(urlBase + "/spaces/" +
 		c.ReadConfig.SpaceID + "/entries?access_token=" +
 		c.ReadConfig.AccessToken + "&limit=200&locale=" +
 		c.ReadConfig.Locale + "&skip=" + strconv.Itoa(skip))

--- a/read/httpgetter.go
+++ b/read/httpgetter.go
@@ -1,6 +1,7 @@
 package read
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -11,7 +12,12 @@ var myClient = &http.Client{Timeout: 10 * time.Second}
 type HttpGetter struct {
 }
 
+// Get makes an http get request and throws an Error if the response
+// statuscode is not 200
 func (hg HttpGetter) Get(url string) (result io.ReadCloser, err error) {
 	resp, err := myClient.Get(url)
+	if resp.StatusCode != 200 && err == nil {
+		err = fmt.Errorf("Http request failed: %s", resp.Status)
+	}
 	return resp.Body, err
 }


### PR DESCRIPTION
A new coommand line argument has been added to contentful-hugo to enable use of the preview-api which will include unpublished content as part of the export